### PR TITLE
Fix warnings issues from t/refhash.t

### DIFF
--- a/t/refhash.t
+++ b/t/refhash.t
@@ -24,6 +24,7 @@ BEGIN {
 }    
 
 use strict;
+use warnings;
 use Tie::RefHash;
 use Data::Dumper;
 my $numtests = 39;
@@ -56,10 +57,18 @@ foreach my $class ('Tie::RefHash', 'Tie::RefHash::Nestable') {
         my ($tr, $tw, $te) = @{$tied_results[$i]};
         
         my $ok = 1;
-        local $^W = 0;
-        $ok = 0 if (defined($or) != defined($tr)) or ($or ne $tr);
-        $ok = 0 if (defined($ow) != defined($tw)) or ($ow ne $tw);
-        $ok = 0 if (defined($oe) != defined($te)) or ($oe ne $te);
+
+        my $t = sub {
+            my ($x, $y) = @_;
+            return 1 if !defined($x) && !defined($y);
+            return 0 if defined($x) != defined($y);
+            return 0 if $x ne $y;
+            return 1;
+        };
+
+        $ok = 0 unless $t->( $or, $tr);
+        $ok = 0 unless $t->( $ow, $tw);
+        $ok = 0 unless $t->( $oe, $te);
         
         if (not $ok) {
             print STDERR


### PR DESCRIPTION
The test file t/refhash.t when checking
some results is raising some warnings
when run with warnings.

Note that ther localize warnings which
was an attempt to fix them is incorrect.

This commit provide one helper function
and enforce warnings by default.